### PR TITLE
docs: enhance README with installation instructions for Swift PackageManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@
 
 The Faro Exporter is an OpenTelemetry exporter that sends telemetry data to [Grafana Faro](https://grafana.com/oss/faro/), an open-source frontend application monitoring solution. This exporter supports both traces and logs in a single instance with automatic session management, allowing you to monitor your iOS applications using either Grafana Cloud or your own self-hosted infrastructure using [Grafana Alloy](https://grafana.com/docs/alloy) as your collector
 
+## Installation
+
+### Swift Package Manager
+
+Add the package dependency to your `Package.swift` file:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/grafana/faro-otel-swift-exporter.git", from: "1.0.0")
+]
+```
+
+Or in Xcode:
+
+1. Go to File > Add Packages...
+2. Enter the package URL: `https://github.com/grafana/faro-otel-swift-exporter.git`
+3. Select the version or branch you want to use
+4. Click "Add Package"
+
 ## Usage
 
 ### Configuration


### PR DESCRIPTION
- Added a new section detailing the installation process for the Faro Exporter using Swift Package Manager.
- Included step-by-step instructions for adding the package dependency in `Package.swift` and through Xcode.
- This update improves accessibility for developers looking to integrate the exporter into their iOS applications.