### PR TITLE
docs: add disclaimer about Frontend Observability being web-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 <img src="./docs/assets/faro_logo.png" alt="Grafana Faro logo" width="300" />
 
-The Faro Exporter is an OpenTelemetry exporter that sends telemetry data to [Grafana Faro](https://grafana.com/oss/faro/), an open-source frontend application monitoring solution. This exporter supports both traces and logs in a single instance with automatic session management, allowing you to monitor your iOS applications using either Grafana Cloud or your own self-hosted infrastructure using [Grafana Alloy](https://grafana.com/docs/alloy) as your collector
+The Faro Exporter is an OpenTelemetry exporter that sends telemetry data to [Grafana Faro](https://grafana.com/oss/faro/), an open-source frontend application monitoring solution. This exporter supports both traces and logs in a single instance with automatic session management, allowing you to monitor your iOS applications using either Grafana Cloud or your own self-hosted infrastructure using [Grafana Alloy](https://grafana.com/docs/alloy) as your collector.
+
+> **Note:** [Grafana Frontend Observability](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/) is built for web applications — there is currently no official mobile observability product from Grafana.
+>
+> This SDK was created as a proof-of-concept to explore mobile telemetry collection using OpenTelemetry and the Faro protocol. It can work well for basic use cases, but please be aware that it is maintained on a best-effort basis and does not come with official support or SLAs.
+>
+> **What you can expect:**
+> - Session tracking and error monitoring may work similarly to web applications
+> - Telemetry data is stored in Loki/Tempo, allowing you to build custom dashboards and run queries in Grafana
+> - Data can be forwarded to [Grafana Alloy](https://grafana.com/docs/alloy/latest/) (with faro receiver enabled) and routed to any observability backend of your choice
+>
+> If you run into issues, feel free to open a GitHub issue — we'll do our best to help on a best-effort basis, but please understand this project is not actively maintained as a product.
 
 ## Installation
 

--- a/Sources/FaroOtelExporter/Internal/DeviceAttributes/FaroDeviceInformationSource.swift
+++ b/Sources/FaroOtelExporter/Internal/DeviceAttributes/FaroDeviceInformationSource.swift
@@ -24,14 +24,29 @@ protocol DeviceInformationSource {
         private let device = WKInterfaceDevice.current()
         private let identifierProvider = FaroPersistentDeviceIdentifierProvider()
 
-        var osName: String { device.systemName }
-        var osVersion: String { device.systemVersion }
-        var deviceBrand: String { device.model } // e.g., "Apple Watch"
-        var deviceModel: String { getDeviceIdentifier() }
+        var osName: String {
+            device.systemName
+        }
+
+        var osVersion: String {
+            device.systemVersion
+        }
+
+        var deviceBrand: String {
+            device.model
+        } // e.g., "Apple Watch"
+        var deviceModel: String {
+            getDeviceIdentifier()
+        }
+
         #if targetEnvironment(simulator)
-            var isPhysical: Bool { false }
+            var isPhysical: Bool {
+                false
+            }
         #else
-            var isPhysical: Bool { true }
+            var isPhysical: Bool {
+                true
+            }
         #endif
 
         var deviceId: String {
@@ -49,14 +64,29 @@ protocol DeviceInformationSource {
         private let device = UIDevice.current
         private let identifierProvider = FaroPersistentDeviceIdentifierProvider()
 
-        var osName: String { device.systemName }
-        var osVersion: String { device.systemVersion }
-        var deviceBrand: String { device.model } // e.g., "iPhone"
-        var deviceModel: String { getDeviceIdentifier() }
+        var osName: String {
+            device.systemName
+        }
+
+        var osVersion: String {
+            device.systemVersion
+        }
+
+        var deviceBrand: String {
+            device.model
+        } // e.g., "iPhone"
+        var deviceModel: String {
+            getDeviceIdentifier()
+        }
+
         #if targetEnvironment(simulator)
-            var isPhysical: Bool { false }
+            var isPhysical: Bool {
+                false
+            }
         #else
-            var isPhysical: Bool { true }
+            var isPhysical: Bool {
+                true
+            }
         #endif
 
         var deviceId: String {
@@ -70,14 +100,29 @@ protocol DeviceInformationSource {
         private let processInfo = ProcessInfo.processInfo
         private let identifierProvider = FaroPersistentDeviceIdentifierProvider()
 
-        var osName: String { "macOS" }
-        var osVersion: String { processInfo.operatingSystemVersionString }
-        var deviceBrand: String { "apple" }
-        var deviceModel: String { getMacModelIdentifier() } // Use hw.model like "MacBookPro18,1"
-        var isPhysical: Bool { true } // Assume physical
-        var deviceId: String { identifierProvider.getIdentifier() }
+        var osName: String {
+            "macOS"
+        }
 
-        // Private helper specific to macOS
+        var osVersion: String {
+            processInfo.operatingSystemVersionString
+        }
+
+        var deviceBrand: String {
+            "apple"
+        }
+
+        var deviceModel: String {
+            getMacModelIdentifier()
+        } // Use hw.model like "MacBookPro18,1"
+        var isPhysical: Bool {
+            true
+        } // Assume physical
+        var deviceId: String {
+            identifierProvider.getIdentifier()
+        }
+
+        /// Private helper specific to macOS
         private func getMacModelIdentifier() -> String {
             var size = 0
             sysctlbyname("hw.model", nil, &size, nil, 0)
@@ -88,18 +133,34 @@ protocol DeviceInformationSource {
     }
 #endif
 
-// Fallback for other potential future platforms
+/// Fallback for other potential future platforms
 struct FallbackDeviceSource: DeviceInformationSource {
     private let processInfo = ProcessInfo.processInfo
     private let identifierProvider = FaroPersistentDeviceIdentifierProvider()
 
-    var osName: String { processInfo.operatingSystemVersionString }
-    var osVersion: String { "" }
-    var deviceBrand: String { "unknown" }
-    var deviceModel: String { "unknown" }
-    var isPhysical: Bool { true }
+    var osName: String {
+        processInfo.operatingSystemVersionString
+    }
 
-    var deviceId: String { identifierProvider.getIdentifier() }
+    var osVersion: String {
+        ""
+    }
+
+    var deviceBrand: String {
+        "unknown"
+    }
+
+    var deviceModel: String {
+        "unknown"
+    }
+
+    var isPhysical: Bool {
+        true
+    }
+
+    var deviceId: String {
+        identifierProvider.getIdentifier()
+    }
 }
 
 // --- Shared Helper Function for Device Model Detection ---

--- a/Sources/FaroOtelExporter/Internal/FaroManagerFactory.swift
+++ b/Sources/FaroOtelExporter/Internal/FaroManagerFactory.swift
@@ -3,7 +3,7 @@ import OpenTelemetrySdk
 
 /// Factory class responsible for creating and managing instances of FaroManager per unique configuration
 final class FaroManagerFactory {
-    // Dictionary to store FaroManager instances by their options
+    /// Dictionary to store FaroManager instances by their options
     private static var managers: [FaroExporterOptions: FaroManager] = [:]
 
     private init() {}

--- a/Sources/FaroOtelExporter/Internal/FaroSpanAdapter.swift
+++ b/Sources/FaroOtelExporter/Internal/FaroSpanAdapter.swift
@@ -32,7 +32,6 @@ enum FaroSpanAdapter {
         }
 
         // Use the standard SpanAdapter to convert the enriched spans
-        let result = SpanAdapter.toProtoResourceSpans(spanDataList: enrichedSpans)
-        return result
+        return SpanAdapter.toProtoResourceSpans(spanDataList: enrichedSpans)
     }
 }

--- a/Sources/FaroOtelExporter/Internal/Models/Models.swift
+++ b/Sources/FaroOtelExporter/Internal/Models/Models.swift
@@ -58,7 +58,7 @@ struct FaroPayload: Encodable {
         }
     }
 
-    // Helper for basic value types
+    /// Helper for basic value types
     private func encodeJSONValue(_ value: Any, forKey key: DynamicCodingKey, into container: inout KeyedEncodingContainer<DynamicCodingKey>) throws {
         if let stringValue = value as? String {
             try container.encode(stringValue, forKey: key)
@@ -74,7 +74,7 @@ struct FaroPayload: Encodable {
         // Note: Arrays and Dictionaries are handled separately before calling this helper
     }
 
-    // Helper for trace/span ID encoding
+    /// Helper for trace/span ID encoding
     private func encodeTraceSpanID(_ value: Any, forKey key: DynamicCodingKey, into container: inout KeyedEncodingContainer<DynamicCodingKey>) throws -> Bool {
         // Check various capitalization and formats
         guard key.stringValue.lowercased() == "traceid" || key.stringValue.lowercased() == "spanid" || key.stringValue.lowercased() == "parentspanid" else {
@@ -102,7 +102,7 @@ struct FaroPayload: Encodable {
         return false // Couldn't encode as trace/span ID
     }
 
-    // Helper for span kind encoding
+    /// Helper for span kind encoding
     private func encodeSpanKind(_ value: Any, forKey key: DynamicCodingKey, into container: inout KeyedEncodingContainer<DynamicCodingKey>) throws -> Bool {
         guard key.stringValue == "kind" else {
             return false // Not the span kind key
@@ -126,7 +126,7 @@ struct FaroPayload: Encodable {
         return false // Couldn't encode as span kind
     }
 
-    // Helper method to encode JSON objects with proper nesting
+    /// Helper method to encode JSON objects with proper nesting
     private func encodeJSONObject(_ jsonObject: [String: Any], into container: inout KeyedEncodingContainer<DynamicCodingKey>) throws {
         for (key, value) in jsonObject {
             let codingKey = DynamicCodingKey(key: key)
@@ -151,7 +151,7 @@ struct FaroPayload: Encodable {
         }
     }
 
-    // Helper method to encode JSON arrays with proper nesting
+    /// Helper method to encode JSON arrays with proper nesting
     private func encodeJSONArray(_ array: [Any], into container: inout UnkeyedEncodingContainer) throws {
         for value in array {
             if let stringValue = value as? String {

--- a/Tests/FaroOtelExporterTests/FaroExporterOptionsTests.swift
+++ b/Tests/FaroOtelExporterTests/FaroExporterOptionsTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class FaroExporterOptionsTests: XCTestCase {
-    // Test that options with same values are equal and have the same hash value
+    /// Test that options with same values are equal and have the same hash value
     func testHashableConformance() {
         // Given
         let options1 = FaroExporterOptions(
@@ -37,7 +37,7 @@ final class FaroExporterOptionsTests: XCTestCase {
         XCTAssertNotEqual(options1.hashValue, options3.hashValue, "Different options should have different hash values")
     }
 
-    // Test that options work correctly as dictionary keys
+    /// Test that options work correctly as dictionary keys
     func testOptionsDictionaryKey() {
         // Given
         let options1 = FaroExporterOptions(
@@ -68,7 +68,7 @@ final class FaroExporterOptionsTests: XCTestCase {
         XCTAssertEqual(optionsDict[options2], "Instance 2", "Should retrieve correct value for options2")
     }
 
-    // Test that nil values are handled correctly
+    /// Test that nil values are handled correctly
     func testHashableWithNilValues() {
         // Given
         let options1 = FaroExporterOptions(

--- a/Tests/FaroOtelExporterTests/FaroOtelLogRecordAdapterTests.swift
+++ b/Tests/FaroOtelExporterTests/FaroOtelLogRecordAdapterTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class FaroOtelLogRecordAdapterTests: XCTestCase {
     var mockDateProvider: MockDateProvider!
 
-    // Test date: February 13, 2009 23:31:30 UTC
+    /// Test date: February 13, 2009 23:31:30 UTC
     let testDate: Date = {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
@@ -197,7 +197,7 @@ final class FaroOtelLogRecordAdapterTests: XCTestCase {
         XCTAssertEqual(result.logs[0].message, "")
     }
 
-    func testChangeUserLogCreatesEvent() {
+    func testChangeUserLogCreatesEvent() throws {
         // Given
         let logRecord = ReadableLogRecord(
             resource: Resource(),
@@ -225,7 +225,7 @@ final class FaroOtelLogRecordAdapterTests: XCTestCase {
         XCTAssertEqual(event.timestamp, testISOString)
         XCTAssertEqual(event.attributes.count, 0)
 
-        let user = result.user!
+        let user = try XCTUnwrap(result.user)
         XCTAssertEqual(user.username, "testuser")
         XCTAssertEqual(user.id, "12345")
         XCTAssertEqual(user.email, "user@example.com")

--- a/Tests/FaroOtelExporterTests/Internal/FaroManagerFactoryTests.swift
+++ b/Tests/FaroOtelExporterTests/Internal/FaroManagerFactoryTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class FaroManagerFactoryTests: XCTestCase {
-    // Test that the factory returns the same instance when called multiple times with the same options
+    /// Test that the factory returns the same instance when called multiple times with the same options
     func testGetInstanceReturnsSameInstance() throws {
         // Given
         let options = FaroExporterOptions(
@@ -19,7 +19,7 @@ final class FaroManagerFactoryTests: XCTestCase {
         XCTAssertTrue(instance1 === instance2, "Factory should return the same instance for the same options")
     }
 
-    // Test that the factory returns different instances when called with different options
+    /// Test that the factory returns different instances when called with different options
     func testGetInstanceReturnsDifferentInstancesWithDifferentOptions() throws {
         // Given
         let options1 = FaroExporterOptions(
@@ -40,7 +40,7 @@ final class FaroManagerFactoryTests: XCTestCase {
         XCTAssertFalse(instance1 === instance2, "Factory should return different instances for different options")
     }
 
-    // Test that options with the same values are considered equal
+    /// Test that options with the same values are considered equal
     func testSameOptionsAreEqual() throws {
         // Given
         let options1 = FaroExporterOptions(

--- a/Tests/FaroOtelExporterTests/Internal/FaroManagerTests.swift
+++ b/Tests/FaroOtelExporterTests/Internal/FaroManagerTests.swift
@@ -288,7 +288,7 @@ final class FaroManagerTests: XCTestCase {
 
     // MARK: - Session Change Tests
 
-    func testSessionChangeCallback() {
+    func testSessionChangeCallback() throws {
         // First, wait for the initial session start event from the FaroManager initialization
         let initialExpectation = XCTestExpectation(description: "Wait for initial session start event")
         mockTransport.sendExpectation = initialExpectation
@@ -326,7 +326,7 @@ final class FaroManagerTests: XCTestCase {
         )
 
         // Get the latest payload (from the session change)
-        let latestPayload = mockTransport.sentPayloads.last!
+        let latestPayload = try XCTUnwrap(mockTransport.sentPayloads.last)
         XCTAssertNotNil(latestPayload.events, "Events should not be nil")
 
         // Verify there's a session_start event in the latest payload

--- a/Tests/FaroOtelExporterTests/Internal/FaroSpanAdapterTests.swift
+++ b/Tests/FaroOtelExporterTests/Internal/FaroSpanAdapterTests.swift
@@ -96,7 +96,7 @@ final class FaroSpanAdapterTests: XCTestCase {
         verifyAttribute(key: "key3", in: foundAttributesMap, hasBoolValue: true)
     }
 
-    func testToProtoResourceSpans_MultipleSpans() {
+    func testToProtoResourceSpans_MultipleSpans() throws {
         // Given
         let sessionId = "test-session-id"
         let spans = [
@@ -131,9 +131,9 @@ final class FaroSpanAdapterTests: XCTestCase {
         XCTAssertTrue(spanAttributeMap.keys.contains("span2"), "span2 should exist in result")
         XCTAssertTrue(spanAttributeMap.keys.contains("span3"), "span3 should exist in result")
 
-        verifyAttribute(key: "span", in: spanAttributeMap["span1"]!, hasStringValue: "1")
-        verifyAttribute(key: "span", in: spanAttributeMap["span2"]!, hasStringValue: "2")
-        verifyAttribute(key: "span", in: spanAttributeMap["span3"]!, hasStringValue: "3")
+        try verifyAttribute(key: "span", in: XCTUnwrap(spanAttributeMap["span1"]), hasStringValue: "1")
+        try verifyAttribute(key: "span", in: XCTUnwrap(spanAttributeMap["span2"]), hasStringValue: "2")
+        try verifyAttribute(key: "span", in: XCTUnwrap(spanAttributeMap["span3"]), hasStringValue: "3")
     }
 
     // MARK: - Helpers

--- a/Tests/FaroOtelExporterTests/Internal/FaroTransportTests.swift
+++ b/Tests/FaroOtelExporterTests/Internal/FaroTransportTests.swift
@@ -20,7 +20,7 @@ final class FaroTransportTests: XCTestCase {
             endpointConfiguration: endpointConfiguration,
             sessionManager: sessionManager,
             httpClient: httpClient,
-            logger: MockFaroLogger(),
+            logger: MockFaroLogger()
         )
     }
 

--- a/Tests/FaroOtelExporterTests/Internal/Utils/FaroEndpointConfigurationExtensionTests.swift
+++ b/Tests/FaroOtelExporterTests/Internal/Utils/FaroEndpointConfigurationExtensionTests.swift
@@ -12,7 +12,7 @@ final class FaroEndpointConfigurationExtensionTests: XCTestCase {
         let config = try FaroEndpointConfiguration.create(from: options)
 
         // Then
-        XCTAssertEqual(config.collectorUrl, URL(string: "https://example.com/api/v1/12345abcdef")!)
+        XCTAssertEqual(config.collectorUrl, URL(string: "https://example.com/api/v1/12345abcdef"))
         XCTAssertEqual(config.apiKey, "12345abcdef")
     }
 
@@ -74,7 +74,7 @@ final class FaroEndpointConfigurationExtensionTests: XCTestCase {
         let config = try FaroEndpointConfiguration.create(from: options)
 
         // Then
-        XCTAssertEqual(config.collectorUrl, URL(string: "https://example.com/api/v1/path/subpath/apikey123")!)
+        XCTAssertEqual(config.collectorUrl, URL(string: "https://example.com/api/v1/path/subpath/apikey123"))
         XCTAssertEqual(config.apiKey, "apikey123")
     }
 


### PR DESCRIPTION
## Summary

  - Adds a disclaimer note to the README clarifying that Grafana Frontend Observability is primarily tailored for web RUM
  - Explains that session tracking and error monitoring capabilities still work for mobile applications
  - Notes that telemetry data is stored in Loki/Tempo for custom dashboards and queries
  - Mentions that users can forward data to Grafana Alloy and integrate with other observability vendors
